### PR TITLE
Fix mockapi endpoint for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage
 .stylelintcache
 cypress/videos
 .idea
+src/environments/.env
+src/environments/*.local

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 export const BASE_URL = `${
 	process.env.NODE_ENV === 'development'
 		? window.location.origin
-		: import.meta.env.VITE_ACTUALS_API_URL
+		: import.meta.env.VITE_API_URL
 }/api`
 
 const Api = axios.create({

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,10 @@
 import axios from 'axios'
 
-export const BASE_URL = `${window.location.origin}/api`
+export const BASE_URL = `${
+	process.env.NODE_ENV === 'development'
+		? window.location.origin
+		: import.meta.env.VITE_ACTUALS_API_URL
+}/api`
 
 const Api = axios.create({
 	baseURL: BASE_URL

--- a/src/api/getActuals.ts
+++ b/src/api/getActuals.ts
@@ -2,6 +2,6 @@ import type { IActual, IActualAPIResponse } from 'types'
 import API from '../api'
 
 export default async function getActuals(): Promise<IActual[]> {
-	const response = await API.get<IActualAPIResponse>('/actuals')
+	const response = await API.get<IActualAPIResponse>('/actuals/1') // 1 is for demo purpose only due to limitation of mockapi.io, Temporary code
 	return response.data.data.children
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -1,10 +1,10 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-	readonly VITE_ACTUALS_API_URL: string
+interface ImportMetaEnvironment {
+	readonly VITE_API_URL: string
 	// more env variables...
 }
 
 interface ImportMeta {
-	readonly env: ImportMetaEnv
+	readonly env: ImportMetaEnvironment
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	readonly VITE_ACTUALS_API_URL: string
+	// more env variables...
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv
+}

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -6,5 +6,6 @@ interface ImportMetaEnvironment {
 }
 
 interface ImportMeta {
+	/* eslint-disable unicorn/prevent-abbreviations */
 	readonly env: ImportMetaEnvironment
 }

--- a/src/environments/.env.local.sample
+++ b/src/environments/.env.local.sample
@@ -1,0 +1,1 @@
+VITE_ACTUALS_API_URL = ''

--- a/src/environments/.env.local.sample
+++ b/src/environments/.env.local.sample
@@ -1,1 +1,1 @@
-VITE_ACTUALS_API_URL = ''
+VITE_API_URL = ''

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -10,7 +10,7 @@ const handlers = [
 			response(context.json(fruits))
 	),
 	rest.get(
-		`api/actuals`,
+		`api/actuals/1`, // 1 is due to limitation of mockapi.io
 		(_, response: ResponseComposition, context: RestContext) =>
 			response(context.json(actuals))
 	)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig(({ mode }) => ({
+	envDir: 'src/environments',
 	optimizeDeps: {
 		disabled: false
 	},


### PR DESCRIPTION

This PR will fix api endpoints for vercel environments

I have updated environment variables inside vercel dashboard for prod and preview environments.

<img width="1668" alt="Screenshot 2023-01-04 at 4 59 05 PM" src="https://user-images.githubusercontent.com/31431173/210550614-0b719bc8-1bd5-46f4-8310-a4cc7429e51b.png">
